### PR TITLE
refactor: replace deprecated WebViewClient method

### DIFF
--- a/app/src/main/java/ir/shecan/fragment/TestDomainFragment.java
+++ b/app/src/main/java/ir/shecan/fragment/TestDomainFragment.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebResourceRequest;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 
@@ -52,12 +53,13 @@ public class TestDomainFragment extends ToolbarFragment {
 
         mWebView.setWebViewClient(new WebViewClient() {
             @Override
-            public boolean shouldOverrideUrlLoading(WebView view, String url) {//for better compatibility
+            public boolean shouldOverrideUrlLoading(WebView view, WebResourceRequest request) {
+                String url = request.getUrl().toString();
                 if (!url.startsWith("https://shecan.ir")) {
                     startActivity(new Intent(Intent.ACTION_VIEW, Uri.parse(url)));
                     return true;
                 }
-                return super.shouldOverrideUrlLoading(view, url);
+                return false;
             }
 
             @Override


### PR DESCRIPTION
## Summary
- replace deprecated `shouldOverrideUrlLoading` WebViewClient override with WebResourceRequest version to remove deprecation warnings

## Testing
- `bash gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_688e5ecf63888330a1d13eed484d47c1